### PR TITLE
Fix invalid Clarity syntax and liquidation surplus bug

### DIFF
--- a/contracts/sbtc-lending-pool.clar
+++ b/contracts/sbtc-lending-pool.clar
@@ -3,6 +3,7 @@
 
 ;; Constants
 (define-constant contract-owner tx-sender)
+(define-constant contract-principal (as-contract tx-sender))
 (define-constant sbtc-token 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token)
 (define-constant err-owner-only (err u100))
 (define-constant err-insufficient-balance (err u101))
@@ -31,11 +32,6 @@
     collateral: uint,
     last-update: uint
   }
-)
-
-;; Private helper functions
-(define-private (get-contract-principal)
-  (as-contract? () tx-sender)
 )
 
 ;; Read-only functions
@@ -83,7 +79,6 @@
   (let
     (
       (current-supply (get-supply tx-sender))
-      (contract-principal (unwrap! (get-contract-principal) (err u999)))
     )
     (asserts! (> amount u0) err-invalid-amount)
 
@@ -116,10 +111,8 @@
     ;; Update total supplied
     (var-set total-supplied (- (var-get total-supplied) amount))
 
-    ;; Transfer sBTC from contract to user (requires as-contract? with allowances)
-    (unwrap! (as-contract? ((with-ft 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token "sbtc-token" amount))
-               (unwrap! (contract-call? 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token transfer amount tx-sender recipient none) (err u998)))
-             (err u999))
+    ;; Transfer sBTC from contract to user
+    (try! (as-contract (contract-call? 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token transfer amount tx-sender recipient none)))
 
     (ok true)
   )
@@ -131,7 +124,6 @@
     (
       (max-borrow (calculate-max-borrow collateral-amount))
       (existing-position (get-borrow tx-sender))
-      (contract-principal (unwrap! (get-contract-principal) (err u999)))
       (recipient tx-sender)
     )
     (asserts! (> collateral-amount u0) err-invalid-amount)
@@ -164,10 +156,8 @@
       )
     )
 
-    ;; Transfer borrowed sBTC from contract to user (requires as-contract? with allowances)
-    (unwrap! (as-contract? ((with-ft 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token "sbtc-token" borrow-amount))
-               (unwrap! (contract-call? 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token transfer borrow-amount tx-sender recipient none) (err u998)))
-             (err u999))
+    ;; Transfer borrowed sBTC from contract to user
+    (try! (as-contract (contract-call? 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token transfer borrow-amount tx-sender recipient none)))
 
     (ok true)
   )
@@ -184,7 +174,6 @@
       (new-debt (- (get amount position) repay-amount))
       (collateral-to-return (/ (* (get collateral position) repay-amount) (get amount position)))
       (remaining-collateral (- (get collateral position) collateral-to-return))
-      (contract-principal (unwrap! (get-contract-principal) (err u999)))
       (recipient tx-sender)
     )
     (asserts! (> amount u0) err-invalid-amount)
@@ -197,9 +186,7 @@
       ;; Full repayment - return all collateral
       (begin
         ;; Transfer collateral back to user
-        (unwrap! (as-contract? ((with-ft 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token "sbtc-token" (get collateral position)))
-                   (unwrap! (contract-call? 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token transfer (get collateral position) tx-sender recipient none) (err u998)))
-                 (err u999))
+        (try! (as-contract (contract-call? 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token transfer (get collateral position) tx-sender recipient none)))
 
         ;; Remove position
         (map-delete borrows tx-sender)
@@ -209,9 +196,7 @@
       ;; Partial repayment - reduce debt proportionally
       (begin
         ;; Transfer proportional collateral back to user
-        (unwrap! (as-contract? ((with-ft 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token "sbtc-token" collateral-to-return))
-                   (unwrap! (contract-call? 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token transfer collateral-to-return tx-sender recipient none) (err u998)))
-                 (err u999))
+        (try! (as-contract (contract-call? 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token transfer collateral-to-return tx-sender recipient none)))
 
         ;; Update position
         (map-set borrows tx-sender {
@@ -235,9 +220,8 @@
       (debt (get amount position))
       (collateral (get collateral position))
       (penalty-amount (/ (* collateral liquidation-penalty) u100))
-      (liquidator-reward penalty-amount)
-      (remaining-collateral (- collateral penalty-amount))
-      (contract-principal (unwrap! (get-contract-principal) (err u999)))
+      (liquidator-share (if (< (+ debt penalty-amount) collateral) (+ debt penalty-amount) collateral))
+      (borrower-refund (- collateral liquidator-share))
       (recipient tx-sender)
     )
     (asserts! (< health-factor liquidation-ratio) err-position-healthy)
@@ -245,10 +229,14 @@
     ;; Liquidator must repay the debt
     (try! (contract-call? 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token transfer debt tx-sender contract-principal none))
 
-    ;; Transfer collateral to liquidator (with penalty bonus)
-    (unwrap! (as-contract? ((with-ft 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token "sbtc-token" collateral))
-               (unwrap! (contract-call? 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token transfer collateral tx-sender recipient none) (err u998)))
-             (err u999))
+    ;; Transfer liquidator's share (debt + penalty) from collateral to liquidator
+    (try! (as-contract (contract-call? 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token transfer liquidator-share tx-sender recipient none)))
+
+    ;; Return remaining collateral to borrower if any
+    (if (> borrower-refund u0)
+      (try! (as-contract (contract-call? 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token transfer borrower-refund tx-sender borrower none)))
+      true
+    )
 
     ;; Remove position
     (map-delete borrows borrower)


### PR DESCRIPTION
## Summary

Fixes both critical bugs reported in #1:

- **Invalid Clarity syntax**: Replaced all `as-contract?` / `with-ft` patterns (which don't exist in Clarity and prevent compilation) with the correct `as-contract` + `contract-call?` pattern. Removed the broken `get-contract-principal` private function and replaced it with a deploy-time constant `(define-constant contract-principal (as-contract tx-sender))`. Removed all `(err u999)` / `(err u998)` unwrap scaffolding in favor of `try!`.
- **Liquidation surplus bug**: Previously the liquidator received ALL collateral regardless of debt size. Now the liquidator receives `min(debt + penalty_amount, collateral)` and any remaining collateral is refunded to the borrower, preventing unfair windfall profits during liquidation.

## Changes

**Issue 1 -- Syntax fixes (5 functions affected):**
| Function | Before (invalid) | After (valid) |
|----------|------------------|---------------|
| `supply` | `(unwrap! (get-contract-principal) (err u999))` | Uses `contract-principal` constant directly |
| `withdraw` | `(as-contract? ((with-ft ...)) ...)` | `(try! (as-contract (contract-call? ... transfer ...)))` |
| `borrow` | `(as-contract? ((with-ft ...)) ...)` | `(try! (as-contract (contract-call? ... transfer ...)))` |
| `repay` (x2) | `(as-contract? ((with-ft ...)) ...)` | `(try! (as-contract (contract-call? ... transfer ...)))` |
| `liquidate` | `(as-contract? ((with-ft ...)) ...)` | `(try! (as-contract (contract-call? ... transfer ...)))` |

**Issue 2 -- Liquidation logic fix:**
| Variable | Before | After |
|----------|--------|-------|
| `liquidator-reward` | `penalty-amount` (unused for transfer) | Replaced by `liquidator-share = min(debt + penalty, collateral)` |
| `remaining-collateral` | `collateral - penalty` (unused) | Replaced by `borrower-refund = collateral - liquidator-share` |
| Transfer to liquidator | `collateral` (100%) | `liquidator-share` (debt + 10% penalty, capped at collateral) |
| Transfer to borrower | Nothing | `borrower-refund` (if > 0) |

## Test plan

- [ ] Run `clarinet check` to verify the contract compiles without syntax errors
- [ ] Test `supply` and `withdraw` round-trip with simnet
- [ ] Test `borrow` and `repay` (full + partial) round-trip
- [ ] Test `liquidate` on an unhealthy position and verify borrower receives surplus collateral
- [ ] Test `liquidate` edge case where debt + penalty >= collateral (borrower gets nothing back)

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)